### PR TITLE
Makes it work—no more WSOD.

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ app.use(cookieSession( {
 var proxy = httpProxy.createProxyServer({
     changeOrigin: true,
     target: {
-        protocol: 'https',
+        protocol: 'https:',
         host: 'localhost',
         port: 2083,
         xfwd: true

--- a/app.js
+++ b/app.js
@@ -26,8 +26,9 @@ app.use(cookieSession( {
 }));
 
 var proxy = httpProxy.createProxyServer({
+    changeOrigin: true,
     target: {
-        protocol: 'https:',
+        protocol: 'https',
         host: 'localhost',
         port: 2083,
         xfwd: true


### PR DESCRIPTION
`http-proxy` doesn't automatically change origins when passing requests, resulting in `localhost` to be checked against SANs and failing. Passing `changeOrigin: true` option handles that internally and everything works just fine.

References:
- https://stackoverflow.com/a/45579167/1219246
- https://github.com/http-party/node-http-proxy#http---https-using-a-pkcs12-client-certificate